### PR TITLE
Upgrade package to new httpx version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,32 +1,32 @@
 -r requirements.txt
 
-pytest-asyncio==0.15.1
-respx==0.17.0
+pytest-asyncio==0.16.0
+respx==0.19.0
 
-isort==5.8.0
-mypy==0.812
+isort==5.10.1
+mypy==0.910
 safety==1.10.3
 cognitive-complexity==1.2.0
 
 mccabe==0.6.1
-flake8==3.9.1
+flake8==4.0.1
 flake8-blind-except==0.2.0
-flake8-broken-line==0.3.0
-flake8-bugbear==21.4.3
+flake8-broken-line==0.4.0
+flake8-bugbear==21.9.2
 flake8-builtins==1.5.3
 flake8-class-attributes-order==0.1.2
 flake8-cognitive-complexity==0.1.0
-flake8-commas==2.0.0
-flake8-comprehensions==3.4.0
+flake8-commas==2.1.0
+flake8-comprehensions==3.7.0
 flake8-debugger==4.0.0
-flake8-eradicate==1.0.0
+flake8-eradicate==1.2.0
 flake8-functions==0.0.6
-flake8-isort==4.0.0
+flake8-isort==4.1.1
 flake8-mock==0.3
 flake8-mutable==1.2.0
 flake8-print==4.0.0
 flake8-pytest==1.3
-flake8-pytest-style==1.4.1
-flake8-quotes==3.2.0
+flake8-pytest-style==1.5.1
+flake8-quotes==3.3.1
 flake8-string-format==0.3.0
 flake8-variables-names==0.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-httpx==0.18.0
-pytest==6.2.3
+httpx==0.21.0
+pytest==6.2.5

--- a/tests/examples/test_disabled.py
+++ b/tests/examples/test_disabled.py
@@ -1,6 +1,6 @@
 from httpx import Client
 
-URL = 'https://google.com'
+URL = 'https://httpbin.org/status/200'
 
 
 def test_integration() -> None:

--- a/tests/examples/test_enabled.py
+++ b/tests/examples/test_enabled.py
@@ -4,7 +4,7 @@ from httpx import AsyncClient, Client
 
 from pytest_httpx_blockage.exceptions import RequestBlockageException
 
-URL = 'https://google.com'
+URL = 'https://httpbin.org/status/200'
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
This change fixes https://github.com/SlavaSkvortsov/pytest-httpx-blockage/issues/2

`pytest-httpx-blockage` is incompatible with `httpcore==0.14.0` and newer.

`httpcore>=0.14.0` is the requirement of `httpx==0.21`: https://github.com/encode/httpx/pull/1935
