### PR TITLE
Upgrade requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,6 @@ isort:
 	isort .
 
 safety:
-	safety check --bare --full-report -r requirements.txt -r requirements-dev.txt
+	safety check --bare -r requirements.txt -r requirements-dev.txt
 
 check: isort flake8 mypy safety test

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ safety==2.3.5
 cognitive-complexity==1.3.0
 
 mccabe==0.7.0
-flake8==6.0.0
+flake8<6
 flake8-blind-except==0.2.1
 flake8-broken-line==0.6.0
 flake8-bugbear==23.2.13
@@ -22,7 +22,6 @@ flake8-debugger==4.1.2
 flake8-eradicate==1.4.0
 flake8-functions==0.0.7
 flake8-isort==6.0.0
-flake8-mock==0.3
 flake8-mutable==1.2.0
 flake8-print==5.0.0
 flake8-pytest==1.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,32 +1,32 @@
 -r requirements.txt
 
-pytest-asyncio==0.16.0
-respx==0.19.0
+pytest-asyncio==0.20.3
+respx==0.20.1
 
-isort==5.10.1
-mypy==0.910
-safety==1.10.3
-cognitive-complexity==1.2.0
+isort==5.12.0
+mypy==1.0.0
+safety==2.3.5
+cognitive-complexity==1.3.0
 
-mccabe==0.6.1
-flake8==4.0.1
-flake8-blind-except==0.2.0
-flake8-broken-line==0.4.0
-flake8-bugbear==21.9.2
-flake8-builtins==1.5.3
-flake8-class-attributes-order==0.1.2
+mccabe==0.7.0
+flake8==6.0.0
+flake8-blind-except==0.2.1
+flake8-broken-line==0.6.0
+flake8-bugbear==23.2.13
+flake8-builtins==2.1.0
+flake8-class-attributes-order==0.1.3
 flake8-cognitive-complexity==0.1.0
 flake8-commas==2.1.0
-flake8-comprehensions==3.7.0
-flake8-debugger==4.0.0
-flake8-eradicate==1.2.0
-flake8-functions==0.0.6
-flake8-isort==4.1.1
+flake8-comprehensions==3.10.1
+flake8-debugger==4.1.2
+flake8-eradicate==1.4.0
+flake8-functions==0.0.7
+flake8-isort==6.0.0
 flake8-mock==0.3
 flake8-mutable==1.2.0
-flake8-print==4.0.0
-flake8-pytest==1.3
-flake8-pytest-style==1.5.1
-flake8-quotes==3.3.1
+flake8-print==5.0.0
+flake8-pytest==1.4
+flake8-pytest-style==1.7.2
+flake8-quotes==3.3.2
 flake8-string-format==0.3.0
-flake8-variables-names==0.0.4
+flake8-variables-names==0.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-httpx==0.21.0
-pytest==6.2.5
+httpx==0.23.3
+pytest==7.2.1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,7 +7,7 @@ from _pytest.pytester import Pytester
 
 @pytest.fixture()
 def read_conftest(request: SubRequest) -> str:
-    return pathlib.Path(request.config.rootdir, 'pytest_httpx_blockage/plugin.py').read_text()
+    return pathlib.Path(request.config.rootdir, 'pytest_httpx_blockage/plugin.py').read_text()  # type: ignore
 
 
 def test_enabled(pytester: Pytester, read_conftest: str) -> None:


### PR DESCRIPTION
We had a conflict of requirements because of the need to have httpx>=0.23.3.

So I updated all requirements. Unfortunately flake-mock hadn't been updated for a while so I had to remove it.